### PR TITLE
Set the crosshair cursor for the hue slider

### DIFF
--- a/color-picker.css
+++ b/color-picker.css
@@ -33,7 +33,7 @@
   float:right;
   border-left:1px solid;
   border-color:inherit;
-  cursor:ns-resize;
+  cursor:crosshair;
   background:transparent url('color-picker-h.png') no-repeat 50% 50%;
   background-image:-webkit-linear-gradient(to top,#f00 0%,#ff0 17%,#0f0 33%,#0ff 50%,#00f 67%,#f0f 83%,#f00 100%);
   background-image:-moz-linear-gradient(to top,#f00 0%,#ff0 17%,#0f0 33%,#0ff 50%,#00f 67%,#f0f 83%,#f00 100%);


### PR DESCRIPTION
Cursor: crosshair allows precise selecting of the color more easily than "ns-resize". Semantically it is also correct: rather than "regulating hue" we usually try to select the point of the necessary color.