### PR TITLE
Add AMD/UMD module handling to color-picker.js

### DIFF
--- a/color-picker-require.html
+++ b/color-picker-require.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Color Picker</title>
+    <link href="color-picker.css" rel="stylesheet">
+
+	<!-- replace with path to require.js instance -->
+	<script src="../requirejs/require.js"></script>
+
+	<script language="javascript">
+	<!--
+		function onLoad() 
+		{
+			var input = document.querySelector('input');
+			input.value = "Loading...";
+
+			require(['color-picker'], function() {
+			
+				input.value = "#ffffff";
+				var picker = new CP(input);
+
+				picker.on("change", function(color) {
+					this.target.value = '#' + color;
+				});
+			});
+		}
+	//-->
+	</script>
+  </head>
+  <body onLoad="onLoad()">
+    <p><input type="text"></p>
+  </body>
+</html>

--- a/color-picker.js
+++ b/color-picker.js
@@ -5,9 +5,30 @@
  * Author: Taufik Nurrohman <https://github.com/tovic>
  * License: MIT
  * ----------------------------------------------------------
+ *
+ * UMD/AMD integration added by http://github.com/RichTeaTime (MIT)
  */
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
 
-(function(win, doc, NS) {
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+
+    } else {
+        // Browser globals (root is window)
+        root.CP = factory();
+    }
+}(this, 
+
+function() {
+
+	var win = window;
+	var doc = document;
 
     var instance = '__instance__',
         first = 'firstChild',
@@ -170,7 +191,7 @@
     (function($) {
 
         // plugin version
-        $.version = '1.3.5';
+        $.version = '1.3.5.1';
 
         // collect all instance(s)
         $[instance] = {};
@@ -209,12 +230,12 @@
         };
         $.HEX2RGB = HEX2RGB;
 
-    })(win[NS] = function(target, events) {
+    })(CP = function(target, events) {
 
         var b = doc.body,
             h = doc.documentElement,
             $ = this,
-            $$ = win[NS],
+            $$ = CP,
             _ = false,
             hooks = {},
             picker = doc.createElement('div'),
@@ -603,4 +624,7 @@
 
     });
 
-})(window, document, 'CP');
+	return CP;
+
+})
+);


### PR DESCRIPTION
I LOVE this color-picker, but am using RequireJS on my project, so would like it in AMD format for bundling and use across a larger application.

This pull request wraps the main factory method in AMD/UMD headers so module loaders can use it.

Deficiencies: In this PR, window.CP is still exposed. But that's not an issue for my application.


... included an example of usage with require.js